### PR TITLE
Updated /orgs end point cache, user roles data, invite API, added a check for name in vendors

### DIFF
--- a/controller/router.go
+++ b/controller/router.go
@@ -51,7 +51,7 @@ func CCRouter(restRouter *gin.Engine) (*gin.Engine, error) {
 func org(c *gin.Context) {
 	ctx := c.Request.Context()
 	d := c.Request.Host
-	redisKey := fmt.Sprintf("org:%s", d)
+	redisKey := fmt.Sprintf("org_%s", d)
 	res, err := redis.GetRedisValue(ctx, redisKey)
 	var outputInt userz.Organization
 	if err == nil && res != "" {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -378,6 +378,12 @@ type PaginatedVendors struct {
 	PageSize   *int      `json:"pageSize"`
 }
 
+type RoleData struct {
+	UserRoleID *string `json:"user_role_id"`
+	Role       *string `json:"role"`
+	UserLspID  *string `json:"user_lsp_id"`
+}
+
 type Sme struct {
 	VendorID         *string   `json:"vendor_id"`
 	SmeID            *string   `json:"sme_id"`
@@ -583,8 +589,8 @@ type UserCourseProgressInput struct {
 }
 
 type UserDetailsRole struct {
-	User  *User     `json:"user"`
-	Roles []*string `json:"roles"`
+	User  *User       `json:"user"`
+	Roles []*RoleData `json:"roles"`
 }
 
 type UserExamAttempts struct {

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -942,7 +942,13 @@ input VendorFilters {
 
 type UserDetailsRole {
   user: User
-  roles: [String]
+  roles: [RoleData]
+}
+
+type RoleData {
+  user_role_id: String
+  role: String
+  user_lsp_id: String
 }
 
 type PaginatedUserDetailsWithRole {
@@ -1151,7 +1157,7 @@ type Query {
 type Mutation {
   registerUsers(input: [UserInput]!): [User]
   inviteUsers(emails: [String!]!, lsp_id: String): Boolean
-  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String): [InviteResponse]
+  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String, tags: String): [InviteResponse]
   updateUser(input: UserInput!): User
   login: User
   addUserLspMap(input: [UserLspMapInput]!): [UserLspMap]

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -40,8 +40,8 @@ func (r *mutationResolver) InviteUsers(ctx context.Context, emails []string, lsp
 }
 
 // InviteUsersWithRole is the resolver for the inviteUsersWithRole field.
-func (r *mutationResolver) InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string) ([]*model.InviteResponse, error) {
-	res, err := handlers.InviteUserWithRole(ctx, emails, *lspID, role)
+func (r *mutationResolver) InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string, tags *string) ([]*model.InviteResponse, error) {
+	res, err := handlers.InviteUserWithRole(ctx, emails, *lspID, role, tags)
 	if err != nil {
 		log.Println("Error while Inviting users with roles: %v", err)
 		return nil, err

--- a/graph/schema_um.gql
+++ b/graph/schema_um.gql
@@ -723,6 +723,7 @@ type Vendor {
 	instagram_url: String
 	twitter_url: String
 	linkedin_url: String
+  services: [String]
 	created_at: String
 	created_by: String
 	updated_at: String
@@ -802,6 +803,7 @@ type VendorProfile {
   crt: Boolean
   cd: Boolean
   is_speaker: Boolean
+  lsp_id: String
   created_at: String
 	created_by: String
 	updated_at: String
@@ -935,11 +937,17 @@ input ExamAttemptsFilters {
 
 input VendorFilters {
   status: String
+  service: String
 }
 
 type UserDetailsRole {
   user: User
-  roles: [String]
+  roles: [RoleData]
+}
+
+type RoleData {
+  user_role_id: String
+  role: String
 }
 
 type PaginatedUserDetailsWithRole {
@@ -1127,7 +1135,7 @@ type Query {
   getVendorExperience(vendor_id: String!, pf_id: String!):[ExperienceVendor]
   getVendorExperienceDetails(vendor_id: String!, pf_id: String!, exp_id: String!): ExperienceVendor
   getVendors(lsp_id: String, filters: VendorFilters): [Vendor]
-  getPaginatedVendors(lsp_id: String, pageCursor: String, Direction: String, pageSize: Int): PaginatedVendors
+  getPaginatedVendors(lsp_id: String, pageCursor: String, Direction: String, pageSize: Int, filters: VendorFilters): PaginatedVendors
   getVendorAdmins(vendor_id: String!): [User]
   getVendorDetails(vendor_id: String!): Vendor
   viewProfileVendorDetails(vendor_id: String!, email: String!): VendorProfile
@@ -1142,6 +1150,7 @@ type Query {
   getPaginatedLspUsersWithRoles(lsp_id: String!, role: [String], pageCursor: String, Direction: String, pageSize: Int): PaginatedUserDetailsWithRole
   getAllOrders(lsp_id: String): [VendorOrder]
   getOrderServices(order_id: [String]):[OrderServices]
+  getSpeakers(lsp_id: String): [Vendor]
 }
 
 type Mutation {

--- a/handlers/orgs/org.go
+++ b/handlers/orgs/org.go
@@ -265,6 +265,12 @@ func UpdateOrganization(ctx context.Context, input model.OrganizationInput) (*mo
 		UpdatedBy:     &orgCass.UpdatedBy,
 		Type:          orgCass.Type,
 	}
+
+	key := fmt.Sprintf("org_%s", orgCass.ZicopsSubdomain)
+	redisBytes, err := json.Marshal(orgCass)
+	if err == nil {
+		redis.SetRedisValue(ctx, key, string(redisBytes))
+	}
 	return result, nil
 
 }

--- a/handlers/user_lsp_handler.go
+++ b/handlers/user_lsp_handler.go
@@ -107,6 +107,26 @@ func AddUserLspMap(ctx context.Context, input []*model.UserLspMapInput, isAdmin 
 	return userLspMaps, nil
 }
 
+// func AddTags(ctx context.Context, userLspId string, userId string, tag string) error {
+// 	data := fmt.Sprintf(`{
+// 		addUserTags(user_lsp_id: "%s",
+// 		user_id: "%s",
+// 		tags: ["%s"])
+// 	  }`, userLspId, userId, tag)
+// 	query := map[string]string{
+// 		"mutation": data,
+// 	}
+
+// 	dataJson, _ := json.Marshal(query)
+// 	request, err := http.NewRequest("POST", "https://demo.zicops.com/ns/query", bytes.NewBuffer(dataJson))
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	request.Header.Add("Authorization", )
+// 	return nil
+// }
+
 func UpdateUserLspMap(ctx context.Context, input model.UserLspMapInput) (*model.UserLspMap, error) {
 	userCass, err := GetUserFromCass(ctx)
 	if err != nil {

--- a/handlers/user_roles.go
+++ b/handlers/user_roles.go
@@ -272,9 +272,14 @@ func GetLspUsersRoles(ctx context.Context, lspID string, role []*string) ([]*mod
 				log.Printf("Got error getting user roles: %v", err)
 				return
 			}
-			roles := make([]*string, 0)
-			for _, v := range userRoles {
-				roles = append(roles, &v.Role)
+			roles := make([]*model.RoleData, 0)
+			for _, vv := range userRoles {
+				v := vv
+				tmp := model.RoleData{
+					UserRoleID: &v.ID,
+					Role:       &v.Role,
+				}
+				roles = append(roles, &tmp)
 			}
 			res[i] = &model.UserDetailsRole{
 				User:  ud,
@@ -388,9 +393,14 @@ func GetPaginatedLspUsersWithRoles(ctx context.Context, lspID string, role []*st
 				log.Printf("Got error getting user roles: %v", err)
 				return
 			}
-			roles := make([]*string, 0)
-			for _, v := range userRoles {
-				roles = append(roles, &v.Role)
+			roles := make([]*model.RoleData, 0)
+			for _, vv := range userRoles {
+				v := vv
+				tmp := model.RoleData{
+					UserRoleID: &v.ID,
+					Role:       &v.Role,
+				}
+				roles = append(roles, &tmp)
 			}
 			res[i] = &model.UserDetailsRole{
 				User:  ud,


### PR DESCRIPTION
- /org endpoint API's cache was not set properly, so changed that
- now along with role, user_lsp_id and user_id would be returned by paginatedUsersWithRole API, as Ankit requested
- inviteUsersWithRole would be taking tags as input as well, regarding this, I want to discuss
- we can't add another vendor with the same name if that exists in our database 