### PR TITLE
Changed invite return type, updated lsp image change, and some modifications

### DIFF
--- a/controller/router.go
+++ b/controller/router.go
@@ -51,7 +51,7 @@ func CCRouter(restRouter *gin.Engine) (*gin.Engine, error) {
 func org(c *gin.Context) {
 	ctx := c.Request.Context()
 	d := c.Request.Host
-	redisKey := fmt.Sprintf("org_%s", d)
+	redisKey := fmt.Sprintf("org:%s", d)
 	res, err := redis.GetRedisValue(ctx, redisKey)
 	var outputInt userz.Organization
 	if err == nil && res != "" {

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -145,8 +145,10 @@ type ComplexityRoot struct {
 	}
 
 	InviteResponse struct {
-		Email   func(childComplexity int) int
-		Message func(childComplexity int) int
+		Email     func(childComplexity int) int
+		Message   func(childComplexity int) int
+		UserID    func(childComplexity int) int
+		UserLspID func(childComplexity int) int
 	}
 
 	LearningSpace struct {
@@ -197,7 +199,7 @@ type ComplexityRoot struct {
 		DeleteCohortImage            func(childComplexity int, cohortID string, filename string) int
 		DeleteSampleFile             func(childComplexity int, sfID string, vendorID string, pType string) int
 		InviteUsers                  func(childComplexity int, emails []string, lspID *string) int
-		InviteUsersWithRole          func(childComplexity int, emails []string, lspID *string, role *string, tags *string) int
+		InviteUsersWithRole          func(childComplexity int, emails []string, lspID *string, role *string) int
 		Login                        func(childComplexity int) int
 		RegisterUsers                func(childComplexity int, input []*model.UserInput) int
 		UpdateClassRoomTraining      func(childComplexity int, input *model.CRTInput) int
@@ -760,7 +762,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	RegisterUsers(ctx context.Context, input []*model.UserInput) ([]*model.User, error)
 	InviteUsers(ctx context.Context, emails []string, lspID *string) (*bool, error)
-	InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string, tags *string) ([]*model.InviteResponse, error)
+	InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string) ([]*model.InviteResponse, error)
 	UpdateUser(ctx context.Context, input model.UserInput) (*model.User, error)
 	Login(ctx context.Context) (*model.User, error)
 	AddUserLspMap(ctx context.Context, input []*model.UserLspMapInput) ([]*model.UserLspMap, error)
@@ -1467,6 +1469,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InviteResponse.Message(childComplexity), true
 
+	case "InviteResponse.user_id":
+		if e.complexity.InviteResponse.UserID == nil {
+			break
+		}
+
+		return e.complexity.InviteResponse.UserID(childComplexity), true
+
+	case "InviteResponse.user_lsp_id":
+		if e.complexity.InviteResponse.UserLspID == nil {
+			break
+		}
+
+		return e.complexity.InviteResponse.UserLspID(childComplexity), true
+
 	case "LearningSpace.created_at":
 		if e.complexity.LearningSpace.CreatedAt == nil {
 			break
@@ -1935,7 +1951,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.InviteUsersWithRole(childComplexity, args["emails"].([]string), args["lsp_id"].(*string), args["role"].(*string), args["tags"].(*string)), true
+		return e.complexity.Mutation.InviteUsersWithRole(childComplexity, args["emails"].([]string), args["lsp_id"].(*string), args["role"].(*string)), true
 
 	case "Mutation.login":
 		if e.complexity.Mutation.Login == nil {
@@ -6395,6 +6411,8 @@ type ExperienceVendor {
 
 type InviteResponse {
   email: String
+  user_id: String
+  user_lsp_id: String
   message: String!
 }
 
@@ -6707,7 +6725,7 @@ type Query {
 type Mutation {
   registerUsers(input: [UserInput]!): [User]
   inviteUsers(emails: [String!]!, lsp_id: String): Boolean
-  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String, tags: String): [InviteResponse]
+  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String): [InviteResponse]
   updateUser(input: UserInput!): User
   login: User
   addUserLspMap(input: [UserLspMapInput]!): [UserLspMap]
@@ -7280,15 +7298,6 @@ func (ec *executionContext) field_Mutation_inviteUsersWithRole_args(ctx context.
 		}
 	}
 	args["role"] = arg2
-	var arg3 *string
-	if tmp, ok := rawArgs["tags"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tags"))
-		arg3, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["tags"] = arg3
 	return args, nil
 }
 
@@ -12658,6 +12667,88 @@ func (ec *executionContext) fieldContext_InviteResponse_email(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _InviteResponse_user_id(ctx context.Context, field graphql.CollectedField, obj *model.InviteResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InviteResponse_user_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InviteResponse_user_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InviteResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InviteResponse_user_lsp_id(ctx context.Context, field graphql.CollectedField, obj *model.InviteResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InviteResponse_user_lsp_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserLspID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InviteResponse_user_lsp_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InviteResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InviteResponse_message(ctx context.Context, field graphql.CollectedField, obj *model.InviteResponse) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InviteResponse_message(ctx, field)
 	if err != nil {
@@ -13450,7 +13541,7 @@ func (ec *executionContext) _Mutation_inviteUsersWithRole(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().InviteUsersWithRole(rctx, fc.Args["emails"].([]string), fc.Args["lsp_id"].(*string), fc.Args["role"].(*string), fc.Args["tags"].(*string))
+		return ec.resolvers.Mutation().InviteUsersWithRole(rctx, fc.Args["emails"].([]string), fc.Args["lsp_id"].(*string), fc.Args["role"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -13474,6 +13565,10 @@ func (ec *executionContext) fieldContext_Mutation_inviteUsersWithRole(ctx contex
 			switch field.Name {
 			case "email":
 				return ec.fieldContext_InviteResponse_email(ctx, field)
+			case "user_id":
+				return ec.fieldContext_InviteResponse_user_id(ctx, field)
+			case "user_lsp_id":
+				return ec.fieldContext_InviteResponse_user_lsp_id(ctx, field)
 			case "message":
 				return ec.fieldContext_InviteResponse_message(ctx, field)
 			}
@@ -43370,6 +43465,14 @@ func (ec *executionContext) _InviteResponse(ctx context.Context, sel ast.Selecti
 		case "email":
 
 			out.Values[i] = ec._InviteResponse_email(ctx, field, obj)
+
+		case "user_id":
+
+			out.Values[i] = ec._InviteResponse_user_id(ctx, field, obj)
+
+		case "user_lsp_id":
+
+			out.Values[i] = ec._InviteResponse_user_lsp_id(ctx, field, obj)
 
 		case "message":
 

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -174,8 +174,10 @@ type ExperienceVendor struct {
 }
 
 type InviteResponse struct {
-	Email   *string `json:"email"`
-	Message string  `json:"message"`
+	Email     *string `json:"email"`
+	UserID    *string `json:"user_id"`
+	UserLspID *string `json:"user_lsp_id"`
+	Message   string  `json:"message"`
 }
 
 type LearningSpace struct {

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -845,6 +845,8 @@ type ExperienceVendor {
 
 type InviteResponse {
   email: String
+  user_id: String
+  user_lsp_id: String
   message: String!
 }
 
@@ -1157,7 +1159,7 @@ type Query {
 type Mutation {
   registerUsers(input: [UserInput]!): [User]
   inviteUsers(emails: [String!]!, lsp_id: String): Boolean
-  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String, tags: String): [InviteResponse]
+  inviteUsersWithRole(emails: [String!]!, lsp_id: String, role: String): [InviteResponse]
   updateUser(input: UserInput!): User
   login: User
   addUserLspMap(input: [UserLspMapInput]!): [UserLspMap]

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -40,8 +40,8 @@ func (r *mutationResolver) InviteUsers(ctx context.Context, emails []string, lsp
 }
 
 // InviteUsersWithRole is the resolver for the inviteUsersWithRole field.
-func (r *mutationResolver) InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string, tags *string) ([]*model.InviteResponse, error) {
-	res, err := handlers.InviteUserWithRole(ctx, emails, *lspID, role, tags)
+func (r *mutationResolver) InviteUsersWithRole(ctx context.Context, emails []string, lspID *string, role *string) ([]*model.InviteResponse, error) {
+	res, err := handlers.InviteUserWithRole(ctx, emails, *lspID, role)
 	if err != nil {
 		log.Println("Error while Inviting users with roles: %v", err)
 		return nil, err

--- a/graph/schema_um.gql
+++ b/graph/schema_um.gql
@@ -845,6 +845,8 @@ type ExperienceVendor {
 
 type InviteResponse {
   email: String
+  user_id: String
+  user_lsp_id: String
   message: String!
 }
 
@@ -948,6 +950,7 @@ type UserDetailsRole {
 type RoleData {
   user_role_id: String
   role: String
+  user_lsp_id: String
 }
 
 type PaginatedUserDetailsWithRole {

--- a/handlers/orgs/lsp.go
+++ b/handlers/orgs/lsp.go
@@ -266,7 +266,7 @@ func UpdateLearningSpace(ctx context.Context, input model.LearningSpaceInput) (*
 		return nil, err
 	}
 	if input.Logo != nil {
-		bucketPath := fmt.Sprintf("%s/%s/%s", orgCass.ID, "logos", base64.URLEncoding.EncodeToString([]byte(input.Profile.Filename)))
+		bucketPath := fmt.Sprintf("%s/%s/%s", orgCass.ID, "logos", base64.URLEncoding.EncodeToString([]byte(input.Logo.Filename)))
 		writer, err := storageC.UploadToGCS(ctx, bucketPath)
 		if err != nil {
 			return nil, err

--- a/handlers/orgs/org.go
+++ b/handlers/orgs/org.go
@@ -266,7 +266,7 @@ func UpdateOrganization(ctx context.Context, input model.OrganizationInput) (*mo
 		Type:          orgCass.Type,
 	}
 
-	key := fmt.Sprintf("org_%s", orgCass.ZicopsSubdomain)
+	key := fmt.Sprintf("org:%s", orgCass.ZicopsSubdomain)
 	redisBytes, err := json.Marshal(orgCass)
 	if err == nil {
 		redis.SetRedisValue(ctx, key, string(redisBytes))
@@ -298,7 +298,7 @@ func GetOrganizations(ctx context.Context, orgIds []*string) ([]*model.Organizat
 				return
 			}
 			orgCass := userz.Organization{}
-			key := fmt.Sprintf("org_%s", *orgID)
+			key := fmt.Sprintf("org:%s", *orgID)
 			res, err := redis.GetRedisValue(ctx, key)
 			if err == nil && res != "" {
 				json.Unmarshal([]byte(res), &orgCass)
@@ -464,7 +464,7 @@ func GetOrganizationsByDomain(ctx context.Context, domain string) ([]*model.Orga
 	outputOrgs := make([]*model.Organization, 1)
 	log.Errorf("domain: %v", domain)
 	orgCass := userz.Organization{}
-	key := fmt.Sprintf("org_%s", domain)
+	key := fmt.Sprintf("org:%s", domain)
 	res, err := redis.GetRedisValue(ctx, key)
 	if err == nil && res != "" {
 		json.Unmarshal([]byte(res), &orgCass)

--- a/handlers/user_cp.go
+++ b/handlers/user_cp.go
@@ -42,6 +42,23 @@ func AddUserCourseProgress(ctx context.Context, input []*model.UserCourseProgres
 			continue
 		}
 		input := *v
+
+		checkQuery := fmt.Sprintf(`SELECT * FROM userz.user_course_progress WHERE user_id='%s' AND topic_id = '%s' AND user_cm_id='%s' ALLOW FILTERING`, input.UserID, input.TopicID, input.UserCourseID)
+		checkMapping := func() (courseProgressMaps []userz.UserCourseProgress, err error) {
+			q := CassUserSession.Query(checkQuery, nil)
+			defer q.Release()
+			iter := q.Iter()
+			return courseProgressMaps, iter.Select(&courseProgressMaps)
+		}
+
+		maps, err := checkMapping()
+		if err != nil {
+			return nil, err
+		}
+		if len(maps) != 0 {
+			continue
+		}
+
 		createdBy := userCass.Email
 		updatedBy := userCass.Email
 		if input.CreatedBy != nil {

--- a/handlers/user_ep.go
+++ b/handlers/user_ep.go
@@ -39,6 +39,22 @@ func AddUserExamProgress(ctx context.Context, input []*model.UserExamProgressInp
 		if input == nil {
 			continue
 		}
+
+		queryStr := fmt.Sprintf(`SELECT * FROM userz.user_exam_progress WHERE user_id='%s' AND user_ea_id='%s' ALLOW FILTERING`, input.UserID, input.UserEaID)
+		checkMapping := func() (maps []userz.UserExamProgress, err error) {
+			q := CassUserSession.Query(queryStr, nil)
+			defer q.Release()
+			iter := q.Iter()
+			return maps, iter.Select(&maps)
+		}
+		examProgress, err := checkMapping()
+		if err != nil {
+			return nil, err
+		}
+		if len(examProgress) != 0 {
+			continue
+		}
+
 		createdBy := userCass.Email
 		updatedBy := userCass.Email
 		if input.CreatedBy != nil {

--- a/handlers/user_exam_result.go
+++ b/handlers/user_exam_result.go
@@ -39,6 +39,22 @@ func AddUserExamResult(ctx context.Context, input []*model.UserExamResultInput) 
 			continue
 		}
 		input := res
+
+		queryStr := fmt.Sprintf(`SELECT * FROM userz.user_exam_results WHERE user_id='%s' AND user_ea_id='%s' ALLOW FILTERING`, input.UserID, input.UserEaID)
+		checkMapping := func() (examResults []userz.UserExamResults, err error) {
+			q := CassUserSession.Query(queryStr, nil)
+			defer q.Release()
+			iter := q.Iter()
+			return examResults, iter.Select(&examResults)
+		}
+		userExamResults, err := checkMapping()
+		if err != nil {
+			return nil, err
+		}
+		if len(userExamResults) != 0 {
+			continue
+		}
+
 		createdBy := userCass.Email
 		updatedBy := userCass.Email
 		if input.CreatedBy != nil {

--- a/handlers/user_exams.go
+++ b/handlers/user_exams.go
@@ -39,6 +39,22 @@ func AddUserExamAttempts(ctx context.Context, input []*model.UserExamAttemptsInp
 		if input == nil {
 			continue
 		}
+
+		checkQuery := fmt.Sprintf(`SELECT * FROM userz.user_exam_attempts WHERE user_id='%s' AND exam_id='%s' AND user_cp_id = '%s' ALLOW FILTERING`, input.UserID, input.ExamID, input.UserCpID)
+		checkMapping := func() (examAttempts []userz.UserExamAttempts, err error) {
+			q := CassUserSession.Query(checkQuery, nil)
+			defer q.Release()
+			iter := q.Iter()
+			return examAttempts, iter.Select(&examAttempts)
+		}
+		attempts, err := checkMapping()
+		if err != nil {
+			return nil, err
+		}
+		if len(attempts) != 0 {
+			continue
+		}
+
 		createdBy := userCass.Email
 		updatedBy := userCass.Email
 		if input.CreatedBy != nil {

--- a/handlers/user_lang_pref.go
+++ b/handlers/user_lang_pref.go
@@ -52,7 +52,7 @@ func AddUserLanguageMap(ctx context.Context, input []*model.UserLanguageMapInput
 			return nil, err
 		}
 		if len(userLangMap) != 0 {
-			return nil, nil
+			continue
 		}
 
 		createdBy := userCass.Email

--- a/handlers/user_lsp_handler.go
+++ b/handlers/user_lsp_handler.go
@@ -107,26 +107,6 @@ func AddUserLspMap(ctx context.Context, input []*model.UserLspMapInput, isAdmin 
 	return userLspMaps, nil
 }
 
-// func AddTags(ctx context.Context, userLspId string, userId string, tag string) error {
-// 	data := fmt.Sprintf(`{
-// 		addUserTags(user_lsp_id: "%s",
-// 		user_id: "%s",
-// 		tags: ["%s"])
-// 	  }`, userLspId, userId, tag)
-// 	query := map[string]string{
-// 		"mutation": data,
-// 	}
-
-// 	dataJson, _ := json.Marshal(query)
-// 	request, err := http.NewRequest("POST", "https://demo.zicops.com/ns/query", bytes.NewBuffer(dataJson))
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	request.Header.Add("Authorization", )
-// 	return nil
-// }
-
 func UpdateUserLspMap(ctx context.Context, input model.UserLspMapInput) (*model.UserLspMap, error) {
 	userCass, err := GetUserFromCass(ctx)
 	if err != nil {


### PR DESCRIPTION
- InviteWithRole API would return userId and userLspId, so joy sir and team can add tags thereon.
- There was a small bug in updating lsp image logo, removed that
- changed the cache key of the organization everywhere, as we had discussed
- added an extra query in each mapping API to check if a mapping already exists or not
